### PR TITLE
darwin patch - fixed executing script in terminal app

### DIFF
--- a/cp/cp/parse.py
+++ b/cp/cp/parse.py
@@ -129,11 +129,11 @@ class Call(Base):
 
 class Parser(Command, Call, Clock, Logpath):
     def pause(self):
-        if 'win' in platform:
+        if 'win32' == platform:
             system('pause')
-        elif 'darwin' in platform:
+        elif 'darwin' == platform:
             system('echo "Close this window to continue..."')
-        elif 'linux' in platform:
+        elif 'linux' == platform[:5]:
             system("printf 'Press [ENTER] to continue...'; read _;")
         else:
             logging.info('Unknown OS Type: %s', platform)

--- a/cp/cp/utils.py
+++ b/cp/cp/utils.py
@@ -1,0 +1,9 @@
+
+from sys import platform
+from os import system
+
+def clear():
+    if 'win32' == platform:
+        system('cls')
+    else:
+        system('clear')

--- a/cp/main.py
+++ b/cp/main.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 from sys import argv, platform
 from logging import basicConfig, DEBUG, info
 from cp.parse import Parser
+from cp.utils import clear
 
 version_info = "v0.2.0"
 
@@ -60,6 +61,8 @@ if __name__ == '__main__':
     namespace = parser.getNamespace()
 
     parser.setCommand()
+
+    clear()
 
     if namespace['file']:
         parser.pipeCall('a')

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -146,7 +146,7 @@ class MetaShell extends Base {
         let object = this.get();
         this.set(object, {
             'command': function (args) {
-                let path = `${object.call} ${object.script}`;
+                let path = '';
                 for (let token of args) {
                     path += ` ${token}`;
                 }
@@ -300,7 +300,7 @@ class SpawnWrapper extends Base {
         }
         return spawn(
             this.object.shell,
-            [...this.object.option, this.object.command(...args)],
+            [...this.object.option, this.object.command(args)],
             model.options
         );
     }

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,0 +1,23 @@
+const terminal = require('./terminal');
+
+let shell, spawn;
+
+shell = new terminal.Shell()
+
+// console.log(shell.object);
+
+spawn = new terminal.SpawnWrapper(shell.object);
+
+// console.log(spawn.object);
+
+tty = spawn.tty({
+    'pause': true,
+    'pipeFile': false,
+    'pipePath': '',
+    'log': true,
+    'args': ['python', `${process.env.USERPROFILE}\\Dropbox\\Source\\Python\\hello.py`],
+    // 'args': ['python', `${process.env.HOME}/Dropbox/Source/Python/hello.py`],
+    'options': new Object()
+});
+
+tty.unref();


### PR DESCRIPTION
this is a patch for issue #49 affecting `darwin` users.

**note**: i did a full debugging session with both `terminal` and `cp`. found a few bugs in `cp` that i didn't catch before and patched those up. most of the changes were localized to methods and functions for the `darwin` system. This is working as intended now.

friendly reminder: don't forget to `apm publish patch` to push the update through.