### PR TITLE
cp options patch - allow opting out of pausing

### DIFF
--- a/cp/cp/parse.py
+++ b/cp/cp/parse.py
@@ -129,11 +129,11 @@ class Call(Base):
 
 class Parser(Command, Call, Clock, Logpath):
     def pause(self):
-        if 'win' in platform:
+        if 'win32' == platform:
             system('pause')
-        elif 'darwin' in platform:
+        elif 'darwin' == platform:
             system('echo "Close this window to continue..."')
-        elif 'linux' in platform:
+        elif 'linux' == platform[:5]:
             system("printf 'Press [ENTER] to continue...'; read _;")
         else:
             logging.info('Unknown OS Type: %s', platform)

--- a/cp/cp/utils.py
+++ b/cp/cp/utils.py
@@ -1,0 +1,9 @@
+
+from sys import platform
+from os import system
+
+def clear():
+    if 'win32' == platform:
+        system('cls')
+    else:
+        system('clear')

--- a/cp/main.py
+++ b/cp/main.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 from sys import argv, platform
 from logging import basicConfig, DEBUG, info
 from cp.parse import Parser
+from cp.utils import clear
 
 version_info = "v0.2.0"
 
@@ -60,6 +61,8 @@ if __name__ == '__main__':
     namespace = parser.getNamespace()
 
     parser.setCommand()
+
+    clear()
 
     if namespace['file']:
         parser.pipeCall('a')

--- a/lib/atom-python-run.js
+++ b/lib/atom-python-run.js
@@ -60,12 +60,6 @@ module.exports = {
                 return;
             }
 
-            // NOTE: 'cp' should always be on!
-            if (!config.pause && !config.pipeFile) {
-                console.log("atom-python-run: `pause` and `pipe` options have been disabled.");
-                console.log("Cowardly refusing to continue...");
-                return;
-            }
             if (config.pipeFile && ('' === config.pipePath || null == config.pipePath)) {
                 console.log("atom-python-run: `pipe` option has been enabled, but has no file to write to.");
                 console.log("Cowardly refusing to continue...");

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -146,7 +146,7 @@ class MetaShell extends Base {
         let object = this.get();
         this.set(object, {
             'command': function (args) {
-                let path = `${object.call} ${object.script}`;
+                let path = '';
                 for (let token of args) {
                     path += ` ${token}`;
                 }
@@ -300,7 +300,7 @@ class SpawnWrapper extends Base {
         }
         return spawn(
             this.object.shell,
-            [...this.object.option, this.object.command(...args)],
+            [...this.object.option, this.object.command(args)],
             model.options
         );
     }

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -273,17 +273,14 @@ class SpawnWrapper extends Base {
         }
         if (model.pause && model.pipeFile) {
             return [this.object.call, this.object.script,
-                '-p', '--file', model.pipePath, ...model.args
+                '-p', '-f', model.pipePath, ...model.args
             ];
         }
-        return null;  // always refuse to pass foreign arguments
+        return [this.object.call, this.object.script, ...model.args];
     }
 
     spawnWin32(model) {
         let args = this.spawnArgs(model);
-        if (null == args) {
-            return null;
-        }
         return spawn(
             this.object.shell,
             [...this.object.option, ...args],
@@ -292,12 +289,7 @@ class SpawnWrapper extends Base {
     }
 
     spawnDarwin(model) {
-        // darwin should never be modified or configured in any way. doing
-        // so risks breaking the required tool chain.
         let args = this.spawnArgs(model);
-        if (null == args) {
-            return null;
-        }
         return spawn(
             this.object.shell,
             [...this.object.option, this.object.command(args)],

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,0 +1,23 @@
+const terminal = require('./terminal');
+
+let shell, spawn;
+
+shell = new terminal.Shell()
+
+// console.log(shell.object);
+
+spawn = new terminal.SpawnWrapper(shell.object);
+
+// console.log(spawn.object);
+
+tty = spawn.tty({
+    'pause': true,
+    'pipeFile': false,
+    'pipePath': '',
+    'log': true,
+    'args': ['python', `${process.env.USERPROFILE}\\Dropbox\\Source\\Python\\hello.py`],
+    // 'args': ['python', `${process.env.HOME}/Dropbox/Source/Python/hello.py`],
+    'options': new Object()
+});
+
+tty.unref();


### PR DESCRIPTION
**Note**: If you haven't already, make sure to merge `master` with `darwin patch` first. Then merge `master` with `cp options patch`. You should avoid merging conflicts this way.

this is a patch for issue #52 affecting **all** users.

patch allows opting out of pausing during execution.

friendly reminder: don't forget to `apm publish patch` to push the update through.