### PR TITLE
added default 'mate-terminal' for linux mint mate release

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -56,6 +56,8 @@ class LinuxSessionWrapper extends Base {
             case 'gnome-fallback':
             case 'cinnamon':
                 return "gnome-terminal";
+            case 'mate':
+                return "mate-terminal";
             case 'xfce':
                 return "xfce4-terminal";
             case 'kde-plasma':
@@ -79,6 +81,8 @@ class LinuxSessionWrapper extends Base {
                 return "konsole";
             case 'LXDE':
                 return "lxterminal";
+            case 'MATE':
+                return "mate-terminal";
             default:
                 return "xterm";
         }
@@ -98,6 +102,7 @@ class LinuxSessionWrapper extends Base {
         // determine the shells default execution option
         switch (shell) {
             case 'gnome-terminal':
+            case 'mate-terminal':
             case 'xfce4-terminal':
                 return "-x";
             case 'konsole':


### PR DESCRIPTION
linux mint (i'm using Linux Mint 18.3 Sylvia Mate edition) uses "mate-terminal"